### PR TITLE
修复高 DPI 下波形缓存缩放异常

### DIFF
--- a/PXView/pv/view/viewport.cpp
+++ b/PXView/pv/view/viewport.cpp
@@ -680,7 +680,13 @@ void Viewport::paintSignals(QPainter &p, QColor fore, QColor back) {
          _view.get_signalHeight() != _curSignalHeight ||
          _view.get_vOffset() != _curVOffset);
 
-    if (view_params_changed || _need_update) {
+    const qreal dpr = devicePixelRatioF();
+    const QSize pixmapSize = (QSizeF(size()) * dpr).toSize();
+    const bool pixmap_changed =
+        _pixmap.isNull() || _pixmap.size() != pixmapSize ||
+        !qFuzzyCompare(_pixmap.devicePixelRatioF(), dpr);
+
+    if (view_params_changed || _need_update || pixmap_changed) {
       rebuilt = true;
       (void)rebuilt;
 #ifndef NDEBUG
@@ -693,13 +699,11 @@ void Viewport::paintSignals(QPainter &p, QColor fore, QColor back) {
       _curSignalHeight = _view.get_signalHeight();
       _curVOffset = _view.get_vOffset();
 
-      const qreal dpr = devicePixelRatioF();
-      _pixmap = QPixmap(size() * dpr);
+      _pixmap = QPixmap(pixmapSize);
       _pixmap.setDevicePixelRatio(dpr);
       _pixmap.fill(Qt::transparent);
 
       QPainter dbp(&_pixmap);
-      dbp.scale(dpr, dpr);
       dbp.translate(0, -_view.get_vOffset());
 
       bool bFirst = true;
@@ -767,9 +771,16 @@ void Viewport::paintSignals(QPainter &p, QColor fore, QColor back) {
       p.restore();
     }
   } else {
+    const qreal dpr = devicePixelRatioF();
+    const QSize pixmapSize = (QSizeF(size()) * dpr).toSize();
+    const bool pixmap_changed =
+        _pixmap.isNull() || _pixmap.size() != pixmapSize ||
+        !qFuzzyCompare(_pixmap.devicePixelRatioF(), dpr);
+
     if (_view.scale() != _curScale || _view.offset() != _curOffset ||
         _view.get_signalHeight() != _curSignalHeight ||
-        _view.get_vOffset() != _curVOffset || _need_update) {
+        _view.get_vOffset() != _curVOffset || _need_update ||
+        pixmap_changed) {
 
       rebuilt = true;
 #ifndef NDEBUG
@@ -782,13 +793,11 @@ void Viewport::paintSignals(QPainter &p, QColor fore, QColor back) {
       _curSignalHeight = _view.get_signalHeight();
       _curVOffset = _view.get_vOffset();
 
-      const qreal dpr = devicePixelRatioF();
-      _pixmap = QPixmap(size() * dpr);
+      _pixmap = QPixmap(pixmapSize);
       _pixmap.setDevicePixelRatio(dpr);
       _pixmap.fill(Qt::transparent);
 
       QPainter dbp(&_pixmap);
-      dbp.scale(dpr, dpr);
       dbp.translate(0, -_view.get_vOffset());
 
       bool isLissa = false;


### PR DESCRIPTION
## 变更内容

本 PR 修复 PXView 在 4K、5K、6K 等高 DPI / 高缩放显示器下，波形区域显示异常的问题。

## 问题原因

`Viewport::paintSignals()` 会先把波形绘制到一个带 `devicePixelRatio` 的 `QPixmap` 缓存中：

- `QPixmap` 已经通过 `setDevicePixelRatio(dpr)` 告诉 Qt 当前缓存对应的高 DPI 比例；
- 但代码又额外调用了 `QPainter::scale(dpr, dpr)`。

这会导致 DPI 缩放被应用两次。
在 100% 缩放显示器上不明显，但在 4K/5K/6K 常见的 150%、200% 缩放环境下，波形缓存会出现尺寸、裁切或位置异常。

另外，原逻辑只在视图缩放、偏移、信号高度等参数变化时重建缓存，没有把 widget 尺寸和 DPR 变化纳入判断。窗口在不同 DPI 显示器之间移动，或者高 DPI 下窗口尺寸变化时，可能复用旧尺寸/旧 DPR 的波形缓存。

## 修复方式

- 移除波形缓存绘制时额外的 `dbp.scale(dpr, dpr)`。
- 保留 `QPixmap::setDevicePixelRatio(dpr)`，由 Qt 正确处理高 DPI 绘制。
- 将 `_pixmap` 的物理尺寸和 `devicePixelRatioF()` 纳入缓存失效判断。
- 当窗口尺寸或 DPR 变化时，自动重建波形缓存。

## 影响范围

主要影响波形区域的缓存绘制逻辑。低 DPI 显示器下行为应保持一致，高 DPI / 多显示器 DPI 切换场景下会正确重建缓存并避免重复缩放。